### PR TITLE
Remove uneeded and problematic FirebaseAnalytics dependency

### DIFF
--- a/ios/awesome_notifications_fcm.podspec
+++ b/ios/awesome_notifications_fcm.podspec
@@ -19,7 +19,7 @@ Complement of Awesome Notifications to allow firebase with all awesome resources
   s.dependency 'IosAwnCore', '0.7.3'
   #s.dependency 'IosAwnFcmCore'
   s.dependency 'IosAwnFcmDist', '0.7.5'
-  s.dependency 'Firebase'
+  s.dependency 'Firebase/CoreOnly'
   s.dependency 'Firebase/Messaging'
   
   s.platform = :ios, '11.0'


### PR DESCRIPTION
This removes FirebaseAnalytics dependency, which is not needed and can also be problematic in some cases (https://github.com/firebase/firebase-ios-sdk/issues/5130)

Currently if you use this plugin on iOS FirebaseAnalytics will be installed with activated tracking and telemetry.
This should not be the case.

Simply using `Firebase/CoreOnly` instead of `Firebase` solves the issue, because it  does not pull FirebaseAnalyctics as dependency.

For me everything is working fine without the Analytics dependency.