### PR TITLE
Fix: dropping plugin v1 embedding

### DIFF
--- a/android/src/main/java/me/carda/awesome_notifications_fcm/FcmDartBackgroundExecutor.java
+++ b/android/src/main/java/me/carda/awesome_notifications_fcm/FcmDartBackgroundExecutor.java
@@ -76,22 +76,6 @@ public class FcmDartBackgroundExecutor extends FcmBackgroundExecutor implements 
         return true;
     }
 
-    private static io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
-            pluginRegistrantCallback;
-
-    /**
-     * Sets the {@code io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback} used to
-     * register plugins with the newly spawned isolate.
-     *
-     * <p>Note: this is only necessary for applications using the V1 engine embedding API as plugins
-     * are automatically registered via reflection in the V2 engine embedding API. If not set,
-     * background message callbacks will not be able to utilize functionality from other plugins.
-     */
-    public static void setPluginRegistrant(
-            io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback callback) {
-        pluginRegistrantCallback = callback;
-    }
-
     private static void addSilentIntent(@NonNull Intent intent){
         silentDataQueue.add(intent);
     }


### PR DESCRIPTION
Latest Flutter 3.29 dropped Android plugin v1 embedding